### PR TITLE
[httplug] guess client and message factory.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,8 @@
     "require": {
         "php": "^5.5.0|^7.0",
         "payum/iso4217": "~1.0",
-        "php-http/httplug": "^1.0",
-        "php-http/message-factory": "^1.0",
+        "php-http/message": "^1.0",
         "php-http/client-implementation": "^1.0",
-        "php-http/discovery": "^0.8",
         "league/url": "~3.0",
         "twig/twig": "~1.0"
     },
@@ -70,9 +68,6 @@
         "fp/klarna-invoice": "0.1.*",
         "stripe/stripe-php": "~2.0|~3.0",
         "php-http/guzzle6-adapter": "^1.0",
-        "php-http/message": "^1.0",
-        "puli/composer-plugin": "^1.0",
-        "guzzlehttp/psr7": "^1.1",
         "ext-soap": "*"
     },
     "replace": {
@@ -109,7 +104,6 @@
         "stripe/stripe-php": "~2.0|~3.0 If you want to use Stripe install stripe/stripe-php:~2.0|~3.0 library",
         "ext-soap": "* If you want to use Payex extension you have to install soap extension"
     },
-    "minimum-stability": "beta",
     "config": {
         "bin-dir": "bin"
     },

--- a/src/Payum/Core/Bridge/Guzzle/HttpClientFactory.php
+++ b/src/Payum/Core/Bridge/Guzzle/HttpClientFactory.php
@@ -4,6 +4,7 @@ namespace Payum\Core\Bridge\Guzzle;
 
 use GuzzleHttp\Client;
 use Http\Discovery\HttpClientDiscovery;
+use Payum\Core\Bridge\Httplug\HttplugClient;
 use Payum\Core\HttpClientInterface;
 
 /**

--- a/src/Payum/Core/Bridge/Httplug/HttplugClient.php
+++ b/src/Payum/Core/Bridge/Httplug/HttplugClient.php
@@ -1,5 +1,5 @@
 <?php
-namespace Payum\Core\Bridge\Guzzle;
+namespace Payum\Core\Bridge\Httplug;
 
 use Payum\Core\HttpClientInterface;
 use Psr\Http\Message\RequestInterface;

--- a/src/Payum/Core/PayumBuilder.php
+++ b/src/Payum/Core/PayumBuilder.php
@@ -109,14 +109,11 @@ class PayumBuilder
     protected $mainRegistry;
 
     /**
+     * @deprecated will be removed in 2.0
+     *
      * @var HttpClientInterface
      */
     protected $httpClient;
-
-    /**
-     * @var string
-     */
-    protected $modelIdProperty;
 
     /**
      * @return static
@@ -363,6 +360,8 @@ class PayumBuilder
     /**
      * @param HttpClientInterface $httpClient
      *
+     * @deprecated this method will be removed in 2.0 Use self::addCoreGatewayFactoryConfig to overwrite http client.
+     *
      * @return static
      */
     public function setHttpClient(HttpClientInterface $httpClient = null)
@@ -393,14 +392,9 @@ class PayumBuilder
 
         $httpRequestVerifier = $this->buildHttpRequestVerifier($this->tokenStorage);
 
-        if (false == $httpClient = $this->httpClient) {
-            $httpClient = HttpClientFactory::create();
-        }
-
         $coreGatewayFactory = $this->buildCoreGatewayFactory(array_replace_recursive([
             'payum.extension.token_factory' => new GenericTokenFactoryExtension($genericTokenFactory),
             'payum.security.token_storage' => $tokenStorage,
-            'payum.http_client' => $httpClient,
         ], $this->coreGatewayFactoryConfig));
 
         $gatewayFactories = array_replace(

--- a/src/Payum/Core/Resources/docs/get-it-started.md
+++ b/src/Payum/Core/Resources/docs/get-it-started.md
@@ -13,7 +13,7 @@ The preferred way to install the library is using [composer](http://getcomposer.
 Run composer require to add dependencies to _composer.json_:
 
 ```bash
-php composer.phar require payum/offline php-http/message php-http/guzzle6-adapter
+php composer.phar require payum/offline php-http/guzzle6-adapter
 ```
 
 _**Note**: Where payum/offline is a php payum extension, you can for example change it to payum/paypal-express-checkout-nvp or payum/stripe. Look at [supported gateways](supported-gateways.md) to find out what you can use._
@@ -51,8 +51,6 @@ $payum = (new PayumBuilder())
     ->addDefaultStorages()
     ->addGateway('aGateway', [
         'factory' => 'offline',
-        'httplug.client' => new Http\Adapter\Guzzle6\Client(),
-        'httplug.message_factory' => new Http\Message\MessageFactory\GuzzleMessageFactory(),
     ])
 
     ->getPayum()
@@ -62,8 +60,6 @@ $payum = (new PayumBuilder())
 _**Note**: There are other [storages](storages.md) available. Such as Doctrine ORM\MongoODM._
 
 _**Note**: Consider using something other than `FilesystemStorage` in production._
-
-_**Note**: Instead of specifying `httplug.client` and `httplug.message_factory` you could use [Httplug discovery](http://docs.php-http.org/en/latest/discovery.html)._
 
 ## prepare.php
 

--- a/src/Payum/Core/Tests/Bridge/Guzzle/HttpClientFactoryTest.php
+++ b/src/Payum/Core/Tests/Bridge/Guzzle/HttpClientFactoryTest.php
@@ -4,7 +4,7 @@ namespace Payum\Core\Tests\Bridge\Guzzle;
 use GuzzleHttp\ClientInterface as GuzzleClientInterface;
 use Payum\Core\Bridge\Guzzle\HttpClient;
 use Payum\Core\Bridge\Guzzle\HttpClientFactory;
-use Payum\Core\Bridge\Guzzle\HttplugClient;
+use Payum\Core\Bridge\Httplug\HttplugClient;
 use Payum\Core\HttpClientInterface;
 
 class HttpClientFactoryTest extends \PHPUnit_Framework_TestCase

--- a/src/Payum/Core/composer.json
+++ b/src/Payum/Core/composer.json
@@ -37,10 +37,8 @@
     "require": {
         "php": "^5.5.0|^7.0",
         "payum/iso4217": "~1.0",
-        "php-http/httplug": "^1.0",
-        "php-http/message-factory": "^1.0",
+        "php-http/message": "^1.0",
         "php-http/client-implementation": "^1.0",
-        "php-http/discovery": "^0.8",
         "league/url": "~3.0",
         "twig/twig": "~1.0"
     },


### PR DESCRIPTION
This is how I see it. User is forced to install one more package `client-implementation` and if it is one of known implementations everything works out of the box. It does not require any additional configuration. 

TODO: other clients like curl buzz have to be added.
